### PR TITLE
|Optimizing list assert equals method, Checking the size of actual an…

### DIFF
--- a/src/main/java/junitx/framework/ListAssert.java
+++ b/src/main/java/junitx/framework/ListAssert.java
@@ -87,15 +87,16 @@ public class ListAssert {
             return;
         }
 
-        for (int ii = 0; ii < expected.size(); ii++) {
-            assertContains(message, actual, expected.get(ii));
-        }
         String formatted = "[length]";
         if (message != null) {
             formatted = message + " " + formatted;
         }
 
         Assert.assertEquals(formatted, expected.size(), actual.size());
+
+        for (int ii = 0; ii < expected.size(); ii++) {
+            assertContains(message, actual, expected.get(ii));
+        }
     }
 
     /**

--- a/src/main/java/junitx/framework/ListAssert.java
+++ b/src/main/java/junitx/framework/ListAssert.java
@@ -92,9 +92,10 @@ public class ListAssert {
             formatted = message + " " + formatted;
         }
 
-        Assert.assertEquals(formatted, expected.size(), actual.size());
+        int sizeOfExpectedList = expected.size();
+        Assert.assertEquals(formatted, sizeOfExpectedList, actual.size());
 
-        for (int ii = 0; ii < expected.size(); ii++) {
+        for (int ii = 0; ii < sizeOfExpectedList; ii++) {
             assertContains(message, actual, expected.get(ii));
         }
     }

--- a/src/test/java/junitx/framework/ListAssertTest.java
+++ b/src/test/java/junitx/framework/ListAssertTest.java
@@ -49,7 +49,7 @@ public class ListAssertTest extends TestCase {
         try {
             ListAssert.assertEquals(expected, actual);
         } catch (AssertionFailedError e) {
-            assertEquals("expecting <2> in <1>", e.getMessage());
+            assertEquals("[length] expected:<2> but was:<1>", e.getMessage());
             return;
         }
         fail();


### PR DESCRIPTION
…d expected lists before comparing on contents|

This will efficiently compare the lists.
If the size of the lists is not equal, it will not go ahead and check for the contents of both lists.

Please merge this request.

Thanks,
Chandan
